### PR TITLE
fix: remove chain-spec-builder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,8 @@ jobs:
           - name: polkadot-omni-node
             projects:
               - polkadot-omni-node
-              - staging-chain-spec-builder
             binaries:
               - polkadot-omni-node
-              - chain-spec-builder
         platform:
           # Linux
           - os: ubuntu-24.04


### PR DESCRIPTION
This PR removes the `chain-spec-builder` from the release. It's been proven we can perform in-code the same chain-spec operations that are already doable with that tool, so there is no need to include it. At least for now.